### PR TITLE
feat: Client-side Hash Verification Layer

### DIFF
--- a/internal/task/types.go
+++ b/internal/task/types.go
@@ -17,4 +17,6 @@ type Request struct {
 	Description string   `json:"description"`
 	Image       string   `json:"image"`
 	Command     []string `json:"command"`
+	ImageHash   string   `json:"image_hash"`
+	CommandHash string   `json:"command_hash"`
 }

--- a/internal/utils/hash.go
+++ b/internal/utils/hash.go
@@ -1,0 +1,31 @@
+package utils
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+func ComputeImageHash(imageName string) (string, error) {
+	cmd := exec.Command("docker", "save", imageName)
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to save image for hashing: %w", err)
+	}
+
+	hash := sha256.Sum256(output)
+	return fmt.Sprintf("%x", hash), nil
+}
+
+func ComputeCommandHash(command []string) string {
+	commandStr := strings.Join(command, " ")
+	hash := sha256.Sum256([]byte(commandStr))
+	return fmt.Sprintf("%x", hash)
+}
+
+func ComputeResultHash(stdout, stderr string, exitCode int) string {
+	combined := fmt.Sprintf("%s%s%d", stdout, stderr, exitCode)
+	hash := sha256.Sum256([]byte(combined))
+	return fmt.Sprintf("%x", hash)
+}


### PR DESCRIPTION
# Implements client-side hash verification for the Parity Protocol task execution system.

## Changes
- Add hash computation utilities for image and command verification
- Extend task request structure to include image and command hashes
- Integrate automatic hash computation in docker service before task upload
- Support deterministic image hashing using `docker save`
- Support command hash computation using sha256

## Related PRs
- **Server-side implementation**: https://github.com/theblitlabs/parity-server/pull/38
- **Runner-side implementation**: https://github.com/theblitlabs/parity-runner/pull/44

## Closes
- https://github.com/theblitlabs/parity-runner/issues/29

## Testing
- [x] Pre-commit checks pass
- [x] Hash computation functions tested
- [x] Integration with docker service verified