### PR TITLE
fix: relocate .env file to user config directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,9 @@ BUILD_FLAGS=-v
 # Installation path
 INSTALL_PATH=/usr/local/bin
 
+# Parity config directory
+PARITY_CONFIG_DIR=$(HOME)/.parity
+
 .PHONY: all build test run clean deps fmt help docker-up docker-down docker-logs docker-build docker-clean install-air watch install uninstall install-lint-tools lint install-hooks format-lint check-format
 
 all: clean build
@@ -139,11 +142,21 @@ help: ## Display this help screen
 install: build ## Install parity command globally
 	@echo "Installing parity to $(INSTALL_PATH)..."
 	@sudo mv $(BINARY_NAME) $(INSTALL_PATH)/$(BINARY_NAME)
+	@echo "Setting up parity config directory..."
+	@mkdir -p $(PARITY_CONFIG_DIR)
+	@if [ -f .env ]; then \
+		cp .env $(PARITY_CONFIG_DIR)/.env; \
+		echo "Config file copied to $(PARITY_CONFIG_DIR)/.env"; \
+	else \
+		echo "No .env file found to copy"; \
+	fi
 	@echo "Installation complete"
 
 uninstall: ## Remove parity command from system
 	@echo "Uninstalling parity from $(INSTALL_PATH)..."
 	@sudo rm -f $(INSTALL_PATH)/$(BINARY_NAME)
+	@echo "Removing parity config directory..."
+	@rm -rf $(PARITY_CONFIG_DIR)
 	@echo "Uninstallation complete"
 
 install-lint-tools: ## Install formatting and linting tools

--- a/Makefile
+++ b/Makefile
@@ -145,8 +145,20 @@ install: build ## Install parity command globally
 	@echo "Setting up parity config directory..."
 	@mkdir -p $(PARITY_CONFIG_DIR)
 	@if [ -f .env ]; then \
-		cp .env $(PARITY_CONFIG_DIR)/.env; \
-		echo "Config file copied to $(PARITY_CONFIG_DIR)/.env"; \
+		if [ -f $(PARITY_CONFIG_DIR)/.env ]; then \
+			echo "Config file already exists at $(PARITY_CONFIG_DIR)/.env"; \
+			read -p "Do you want to replace it? (Y/n): " -n 1 -r; \
+			echo; \
+			if [[ $$REPLY =~ ^[Yy]$$ ]] || [[ -z $$REPLY ]]; then \
+				cp .env $(PARITY_CONFIG_DIR)/.env; \
+				echo "Config file replaced at $(PARITY_CONFIG_DIR)/.env"; \
+			else \
+				echo "Keeping existing config file at $(PARITY_CONFIG_DIR)/.env"; \
+			fi; \
+		else \
+			cp .env $(PARITY_CONFIG_DIR)/.env; \
+			echo "Config file copied to $(PARITY_CONFIG_DIR)/.env"; \
+		fi; \
 	else \
 		echo "No .env file found to copy"; \
 	fi

--- a/README.md
+++ b/README.md
@@ -56,7 +56,17 @@ make build
 
 ## Configuration
 
-The client is configured using environment variables through a `.env` file:
+The client is configured using environment variables through a `.env` file. The application supports multiple config file locations for development and production use.
+
+### Config File Locations
+
+The client looks for configuration files in the following order:
+
+1. **Production (after `make install`)**: `~/.parity/.env`
+2. **Development/Custom path**: Specified via `--config-path` flag
+3. **Local fallback**: `./.env` in the current directory
+
+### Initial Setup
 
 1. Copy the example environment file:
 
@@ -84,11 +94,39 @@ ETHEREUM_CHAIN_ID=11155111
 ETHEREUM_RPC="https://eth-sepolia.g.alchemy.com/v2/YOUR_API_KEY"
 ```
 
-You can also specify a custom config path using the `--config-path` flag:
+### Installing the Client
+
+To install the client globally and set up the production config:
+
+```bash
+make install
+```
+
+This will:
+
+- Install the `parity-client` binary to `/usr/local/bin`
+- Create the `~/.parity` directory
+- Copy your current `.env` file to `~/.parity/.env`
+
+After installation, you can run `parity-client` from any directory and it will automatically use the config from `~/.parity/.env`.
+
+### Custom Config Path
+
+You can specify a custom config path using the `--config-path` flag:
 
 ```bash
 parity-client --config-path /path/to/custom.env
 ```
+
+### Uninstalling
+
+To remove the client and clean up config files:
+
+```bash
+make uninstall
+```
+
+This removes both the binary and the `~/.parity` directory.
 
 ## Usage
 
@@ -164,6 +202,8 @@ Common issues and solutions:
 1. **Configuration Issues**
 
    - Ensure your `.env` file exists and is properly configured
+   - For development: Check `.env` in your project directory
+   - For installed client: Check `~/.parity/.env` or run `parity-client --help` to see current config path
    - Check that all required environment variables are set
    - Verify the config path if using `--config-path`
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ This will:
 - Install the `parity-client` binary to `/usr/local/bin`
 - Create the `~/.parity` directory
 - Copy your current `.env` file to `~/.parity/.env`
+- If `~/.parity/.env` already exists, prompt you to confirm replacement (defaults to Yes)
 
 After installation, you can run `parity-client` from any directory and it will automatically use the config from `~/.parity/.env`.
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/theblitlabs/parity-client/cmd/cli"
 	"github.com/theblitlabs/parity-client/internal/commands"
 	"github.com/theblitlabs/parity-client/internal/config"
+	"github.com/theblitlabs/parity-client/internal/utils"
 )
 
 var (
@@ -38,14 +39,14 @@ var rootCmd = &cobra.Command{
 			gologger.InitWithMode(gologger.LogModePretty)
 		}
 		if configPath == "" {
-			configPath = ".env"
+			configPath = utils.GetDefaultConfigPath()
 		}
 	},
 }
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(&logMode, "log", "pretty", "Log mode: debug, pretty, info, prod, test")
-	rootCmd.PersistentFlags().StringVar(&configPath, "config-path", "", "Path to config file (default: .env)")
+	rootCmd.PersistentFlags().StringVar(&configPath, "config-path", "", "Path to config file (default: ~/.parity/.env or ./.env)")
 
 	commands.AddCommands(rootCmd)
 }

--- a/internal/utils/config_path.go
+++ b/internal/utils/config_path.go
@@ -26,5 +26,5 @@ func GetDefaultConfigPath() string {
 
 func EnsureConfigDir() error {
 	configDir := GetParityConfigDir()
-	return os.MkdirAll(configDir, 0755)
+	return os.MkdirAll(configDir, 0o755)
 }

--- a/internal/utils/config_path.go
+++ b/internal/utils/config_path.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func GetParityConfigDir() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return ".parity"
+	}
+	return filepath.Join(homeDir, ".parity")
+}
+
+func GetDefaultConfigPath() string {
+	configDir := GetParityConfigDir()
+	configPath := filepath.Join(configDir, ".env")
+
+	if _, err := os.Stat(configPath); err == nil {
+		return configPath
+	}
+
+	return ".env"
+}
+
+func EnsureConfigDir() error {
+	configDir := GetParityConfigDir()
+	return os.MkdirAll(configDir, 0755)
+}


### PR DESCRIPTION
## Summary

This PR fixes the issue where the `.env` file was not accessible after running `make install`, preventing the parity client from running from any directory other than the project root.

## Changes

### Core Implementation

- **New utility package**: `internal/utils/config_path.go` with functions to manage config directory and paths
- **Updated main.go**: Modified to use the new config path resolution logic
- **Enhanced Makefile**: Updated install/uninstall targets to handle config file placement

### Config File Resolution

The client now looks for configuration in this order:

1. **Production**: `~/.parity/.env` (after `make install`)
2. **Custom path**: Via `--config-path` flag
3. **Local fallback**: `./.env` in current directory

### Installation Process

- `make install` now creates `~/.parity` directory
- Copies existing `.env` to `~/.parity/.env`
- `make uninstall` cleans up both binary and config directory

### Documentation

- Updated README with detailed config file location behavior
- Added installation/uninstallation instructions
- Enhanced troubleshooting section

## Testing

- ✅ Code compiles successfully
- ✅ Config path resolution works correctly
- ✅ Help text shows proper config locations
- ✅ All formatting and linting checks pass

## Usage After Install

```bash
make install
cd /any/directory
parity-client --help  # Works from anywhere!
```

Fixes the issue where installed parity command couldn't find .env from any directory.
