### PR TITLE
feat: Add comprehensive health check endpoints with real-time monitoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,14 @@ deps:
 	go mod download
 
 build: ## Build the application
-	$(GOBUILD) $(BUILD_FLAGS) -o $(BINARY_NAME) ./cmd
+	$(eval VERSION := $(shell git describe --tags --always --dirty))
+	$(eval COMMIT := $(shell git rev-parse HEAD))
+	$(eval BUILD_TIME := $(shell date -u '+%Y-%m-%d_%H:%M:%S'))
+	$(GOBUILD) $(BUILD_FLAGS) \
+		-ldflags "-X github.com/theblitlabs/parity-client/internal/version.Version=$(VERSION) \
+		-X github.com/theblitlabs/parity-client/internal/version.CommitSHA=$(COMMIT) \
+		-X github.com/theblitlabs/parity-client/internal/version.BuildTime=$(BUILD_TIME)" \
+		-o $(BINARY_NAME) ./cmd
 	chmod +x $(BINARY_NAME)
 
 test: setup-coverage ## Run tests with coverage
@@ -72,6 +79,9 @@ balance:  ## Check token balances
 
 auth:  ## Authenticate with the network
 	$(GOCMD) run $(MAIN_PATH) auth
+
+health:  ## Check health status
+	$(GOCMD) run $(MAIN_PATH) health
 
 clean: ## Clean build files
 	rm -f $(BINARY_NAME)

--- a/README.md
+++ b/README.md
@@ -361,6 +361,111 @@ curl -X POST http://localhost:3000/api/tasks \
   }'
 ```
 
+### Health Monitoring
+
+The parity client provides comprehensive health monitoring endpoints for operational visibility:
+
+#### Basic Health Check
+
+```bash
+# Command line health check
+parity-client health
+
+# HTTP health check
+curl http://localhost:3000/health
+```
+
+#### Detailed Health Information
+
+```bash
+# Get detailed health status
+parity-client health --detailed
+
+# HTTP detailed health check
+curl http://localhost:3000/health/detailed
+```
+
+#### Kubernetes-style Probes
+
+```bash
+# Readiness probe (for Kubernetes deployments)
+curl http://localhost:3000/health/ready
+
+# Liveness probe (for Kubernetes deployments)
+curl http://localhost:3000/health/live
+```
+
+#### Health Check Options
+
+```bash
+# Check health with custom endpoint
+parity-client health --endpoint http://your-server:8080
+
+# Set custom timeout
+parity-client health --timeout 30s
+
+# Get detailed information
+parity-client health --detailed
+```
+
+#### Health Check Response Format
+
+Basic health check response:
+```json
+{
+  "status": "healthy",
+  "timestamp": "2024-01-15T10:30:00Z",
+  "version": "v1.0.0",
+  "uptime": "2h30m15s",
+  "services": {
+    "blockchain": "configured",
+    "ipfs": "configured",
+    "runner": "configured"
+  }
+}
+```
+
+Detailed health check response:
+```json
+{
+  "status": "healthy",
+  "timestamp": "2024-01-15T10:30:00Z",
+  "version": "v1.0.0",
+  "uptime": "2h30m15s",
+  "services": {
+    "blockchain": {
+      "status": "healthy",
+      "last_check": "2024-01-15T10:29:55Z",
+      "latency": "125ms"
+    },
+    "ipfs": {
+      "status": "healthy",
+      "last_check": "2024-01-15T10:29:58Z",
+      "latency": "45ms"
+    },
+    "runner": {
+      "status": "healthy",
+      "last_check": "2024-01-15T10:30:00Z",
+      "latency": "78ms"
+    }
+  },
+  "config": {
+    "server_host": "0.0.0.0",
+    "server_port": 3000,
+    "blockchain_rpc": "https://your-blockchain-node.com",
+    "ipfs_endpoint": "http://localhost:5001",
+    "runner_url": "http://localhost:8080"
+  }
+}
+```
+
+**Note**: All health check data is real-time:
+- **Uptime**: Actual application uptime since start
+- **Version**: Real version from git tags and build info
+- **Service Status**: Live connectivity tests to blockchain, IPFS, and runner services
+- **Latency**: Actual response times from service health checks
+- **Configuration**: Real configuration values from your environment
+
 ## Configuration Files
 
 ### Model Configuration Examples
@@ -469,10 +574,12 @@ parity-client fl create-session \
 
 ### Health & Status Endpoints
 
-| Method | Endpoint    | Description   |
-| ------ | ----------- | ------------- |
-| GET    | /api/health | Health check  |
-| GET    | /api/status | System status |
+| Method | Endpoint           | Description                    |
+| ------ | ------------------ | ------------------------------ |
+| GET    | /health            | Basic health check             |
+| GET    | /health/detailed   | Detailed health information    |
+| GET    | /health/ready      | Readiness probe                |
+| GET    | /health/live       | Liveness probe                 |
 
 ## Development
 

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -9,5 +9,6 @@ func AddCommands(rootCmd *cobra.Command) {
 	rootCmd.AddCommand(llmCmd)
 	rootCmd.AddCommand(flCmd)
 	rootCmd.AddCommand(storageCmd)
+	rootCmd.AddCommand(healthCmd)
 	rootCmd.AddCommand(GetReputationCommand())
 }

--- a/internal/commands/health.go
+++ b/internal/commands/health.go
@@ -1,0 +1,86 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/theblitlabs/gologger"
+)
+
+var healthCmd = &cobra.Command{
+	Use:   "health",
+	Short: "Check health status of the parity client",
+	Long:  `Check the health status of the parity client and its connected services`,
+	Run:   runHealthCheck,
+}
+
+var (
+	healthDetailed bool
+	healthEndpoint string
+	healthTimeout  time.Duration
+)
+
+func init() {
+	healthCmd.Flags().BoolVar(&healthDetailed, "detailed", false, "Get detailed health information")
+	healthCmd.Flags().StringVar(&healthEndpoint, "endpoint", "http://localhost:3000", "Health check endpoint URL")
+	healthCmd.Flags().DurationVar(&healthTimeout, "timeout", 10*time.Second, "Timeout for health check request")
+}
+
+func runHealthCheck(cmd *cobra.Command, args []string) {
+	logger := gologger.Get().With().Str("component", "health-cmd").Logger()
+
+	var url string
+	if healthDetailed {
+		url = fmt.Sprintf("%s/health/detailed", healthEndpoint)
+	} else {
+		url = fmt.Sprintf("%s/health", healthEndpoint)
+	}
+
+	logger.Info().Str("url", url).Msg("Checking health status")
+
+	client := &http.Client{
+		Timeout: healthTimeout,
+	}
+
+	resp, err := client.Get(url)
+	if err != nil {
+		logger.Error().Err(err).Msg("Failed to connect to health endpoint")
+		fmt.Printf("❌ Health check failed: %v\n", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		logger.Error().Int("status_code", resp.StatusCode).Msg("Health check returned non-OK status")
+		fmt.Printf("❌ Health check failed with status: %d\n", resp.StatusCode)
+		return
+	}
+
+	var result map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		logger.Error().Err(err).Msg("Failed to decode health response")
+		fmt.Printf("❌ Failed to decode health response: %v\n", err)
+		return
+	}
+
+	// Pretty print the JSON response
+	prettyJSON, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		logger.Error().Err(err).Msg("Failed to marshal health response")
+		fmt.Printf("❌ Failed to format health response: %v\n", err)
+		return
+	}
+
+	fmt.Printf("✅ Health check successful\n")
+	fmt.Printf("Status: %s\n", result["status"])
+	fmt.Printf("Timestamp: %s\n", result["timestamp"])
+	fmt.Printf("Version: %s\n", result["version"])
+
+	if healthDetailed {
+		fmt.Printf("\nDetailed Information:\n")
+		fmt.Println(string(prettyJSON))
+	}
+}

--- a/internal/handlers/health.go
+++ b/internal/handlers/health.go
@@ -15,9 +15,7 @@ import (
 	"github.com/theblitlabs/parity-client/internal/version"
 )
 
-var (
-	startTime = time.Now()
-)
+var startTime = time.Now()
 
 type HealthHandler struct {
 	config *config.Config

--- a/internal/handlers/health.go
+++ b/internal/handlers/health.go
@@ -1,0 +1,286 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/ethereum/go-ethereum/ethclient"
+	shell "github.com/ipfs/go-ipfs-api"
+	"github.com/rs/zerolog"
+	"github.com/theblitlabs/gologger"
+	"github.com/theblitlabs/parity-client/internal/config"
+	"github.com/theblitlabs/parity-client/internal/version"
+)
+
+var (
+	startTime = time.Now()
+)
+
+type HealthHandler struct {
+	config *config.Config
+	logger zerolog.Logger
+}
+
+type HealthStatus struct {
+	Status    string            `json:"status"`
+	Timestamp time.Time         `json:"timestamp"`
+	Version   string            `json:"version"`
+	Uptime    string            `json:"uptime"`
+	Services  map[string]string `json:"services,omitempty"`
+}
+
+type DetailedHealthStatus struct {
+	Status    string                 `json:"status"`
+	Timestamp time.Time              `json:"timestamp"`
+	Version   string                 `json:"version"`
+	Uptime    string                 `json:"uptime"`
+	Services  map[string]ServiceInfo `json:"services"`
+	Config    ConfigInfo             `json:"config"`
+}
+
+type ServiceInfo struct {
+	Status    string    `json:"status"`
+	LastCheck time.Time `json:"last_check"`
+	Error     string    `json:"error,omitempty"`
+	Latency   string    `json:"latency,omitempty"`
+}
+
+type ConfigInfo struct {
+	ServerHost    string `json:"server_host"`
+	ServerPort    int    `json:"server_port"`
+	BlockchainRPC string `json:"blockchain_rpc"`
+	IPFSEndpoint  string `json:"ipfs_endpoint"`
+	RunnerURL     string `json:"runner_url"`
+}
+
+func NewHealthHandler(cfg *config.Config) *HealthHandler {
+	return &HealthHandler{
+		config: cfg,
+		logger: gologger.Get().With().Str("component", "health").Logger(),
+	}
+}
+
+func (h *HealthHandler) getUptime() string {
+	uptime := time.Since(startTime)
+	return uptime.String()
+}
+
+func (h *HealthHandler) checkBlockchainHealth() ServiceInfo {
+	start := time.Now()
+	status := ServiceInfo{
+		Status:    "unhealthy",
+		LastCheck: time.Now(),
+	}
+
+	if h.config.BlockchainNetwork.RPC == "" {
+		status.Error = "Blockchain RPC URL not configured"
+		return status
+	}
+
+	client, err := ethclient.Dial(h.config.BlockchainNetwork.RPC)
+	if err != nil {
+		status.Error = fmt.Sprintf("Failed to connect to blockchain: %v", err)
+		return status
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err = client.BlockNumber(ctx)
+	if err != nil {
+		status.Error = fmt.Sprintf("Failed to get block number: %v", err)
+		return status
+	}
+
+	status.Status = "healthy"
+	status.Latency = time.Since(start).String()
+	return status
+}
+
+func (h *HealthHandler) checkIPFSHealth() ServiceInfo {
+	start := time.Now()
+	status := ServiceInfo{
+		Status:    "unhealthy",
+		LastCheck: time.Now(),
+	}
+
+	if h.config.BlockchainNetwork.IPFSEndpoint == "" {
+		status.Error = "IPFS endpoint not configured"
+		return status
+	}
+
+	sh := shell.NewShell(h.config.BlockchainNetwork.IPFSEndpoint)
+
+	// Test IPFS connection by getting version
+	_, _, err := sh.Version()
+	if err != nil {
+		status.Error = fmt.Sprintf("Failed to connect to IPFS: %v", err)
+		return status
+	}
+
+	status.Status = "healthy"
+	status.Latency = time.Since(start).String()
+	return status
+}
+
+func (h *HealthHandler) checkRunnerHealth() ServiceInfo {
+	start := time.Now()
+	status := ServiceInfo{
+		Status:    "unhealthy",
+		LastCheck: time.Now(),
+	}
+
+	if h.config.Runner.ServerURL == "" {
+		status.Error = "Runner URL not configured"
+		return status
+	}
+
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	// Try to connect to runner health endpoint
+	resp, err := client.Get(fmt.Sprintf("%s/health", h.config.Runner.ServerURL))
+	if err != nil {
+		status.Error = fmt.Sprintf("Failed to connect to runner: %v", err)
+		return status
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		status.Error = fmt.Sprintf("Runner returned status: %d", resp.StatusCode)
+		return status
+	}
+
+	status.Status = "healthy"
+	status.Latency = time.Since(start).String()
+	return status
+}
+
+func (h *HealthHandler) HandleHealthCheck(w http.ResponseWriter, r *http.Request) {
+	// Quick health check - only check if services are configured
+	services := make(map[string]string)
+
+	if h.config.BlockchainNetwork.RPC != "" {
+		services["blockchain"] = "configured"
+	}
+	if h.config.BlockchainNetwork.IPFSEndpoint != "" {
+		services["ipfs"] = "configured"
+	}
+	if h.config.Runner.ServerURL != "" {
+		services["runner"] = "configured"
+	}
+
+	status := HealthStatus{
+		Status:    "healthy",
+		Timestamp: time.Now(),
+		Version:   version.GetShortVersion(),
+		Uptime:    h.getUptime(),
+		Services:  services,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	if err := json.NewEncoder(w).Encode(status); err != nil {
+		h.logger.Error().Err(err).Msg("Failed to encode health status")
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+	}
+}
+
+func (h *HealthHandler) HandleDetailedHealthCheck(w http.ResponseWriter, r *http.Request) {
+	services := make(map[string]ServiceInfo)
+
+	// Check blockchain connection
+	services["blockchain"] = h.checkBlockchainHealth()
+
+	// Check IPFS connection
+	services["ipfs"] = h.checkIPFSHealth()
+
+	// Check runner service
+	services["runner"] = h.checkRunnerHealth()
+
+	// Determine overall status
+	overallStatus := "healthy"
+	for _, service := range services {
+		if service.Status != "healthy" {
+			overallStatus = "degraded"
+			break
+		}
+	}
+
+	status := DetailedHealthStatus{
+		Status:    overallStatus,
+		Timestamp: time.Now(),
+		Version:   version.GetShortVersion(),
+		Uptime:    h.getUptime(),
+		Services:  services,
+		Config: ConfigInfo{
+			ServerHost:    h.config.Server.Host,
+			ServerPort:    h.config.Server.Port,
+			BlockchainRPC: h.config.BlockchainNetwork.RPC,
+			IPFSEndpoint:  h.config.BlockchainNetwork.IPFSEndpoint,
+			RunnerURL:     h.config.Runner.ServerURL,
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	if err := json.NewEncoder(w).Encode(status); err != nil {
+		h.logger.Error().Err(err).Msg("Failed to encode detailed health status")
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+	}
+}
+
+func (h *HealthHandler) HandleReadinessCheck(w http.ResponseWriter, r *http.Request) {
+	// Readiness check - verify all required services are available
+	blockchainHealth := h.checkBlockchainHealth()
+	ipfsHealth := h.checkIPFSHealth()
+	runnerHealth := h.checkRunnerHealth()
+
+	ready := blockchainHealth.Status == "healthy" &&
+		ipfsHealth.Status == "healthy" &&
+		runnerHealth.Status == "healthy"
+
+	status := HealthStatus{
+		Status:    "ready",
+		Timestamp: time.Now(),
+		Version:   version.GetShortVersion(),
+		Uptime:    h.getUptime(),
+	}
+
+	if !ready {
+		status.Status = "not_ready"
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if err := json.NewEncoder(w).Encode(status); err != nil {
+		h.logger.Error().Err(err).Msg("Failed to encode readiness status")
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+	}
+}
+
+func (h *HealthHandler) HandleLivenessCheck(w http.ResponseWriter, r *http.Request) {
+	// Liveness check - just verify the application is running
+	status := HealthStatus{
+		Status:    "alive",
+		Timestamp: time.Now(),
+		Version:   version.GetShortVersion(),
+		Uptime:    h.getUptime(),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	if err := json.NewEncoder(w).Encode(status); err != nil {
+		h.logger.Error().Err(err).Msg("Failed to encode liveness status")
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+	}
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,35 @@
+package version
+
+import (
+	"fmt"
+	"runtime"
+)
+
+var (
+	// These will be set during build
+	Version   = "dev"
+	CommitSHA = "unknown"
+	BuildTime = "unknown"
+	GoVersion = runtime.Version()
+)
+
+// GetVersion returns the full version information
+func GetVersion() string {
+	return fmt.Sprintf("v%s", Version)
+}
+
+// GetBuildInfo returns detailed build information
+func GetBuildInfo() map[string]string {
+	return map[string]string{
+		"version":    Version,
+		"commit":     CommitSHA,
+		"build_time": BuildTime,
+		"go_version": GoVersion,
+		"platform":   fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}
+
+// GetShortVersion returns just the version string
+func GetShortVersion() string {
+	return Version
+}


### PR DESCRIPTION
## Health Check Implementation

This PR adds comprehensive health monitoring capabilities to the parity client with real-time data collection and service connectivity testing.

### Features Added

#### HTTP Health Endpoints
- `/health` - Basic health check with service configuration status
- `/health/detailed` - Detailed health information with live service connectivity tests
- `/health/ready` - Kubernetes readiness probe with dependency validation
- `/health/live` - Kubernetes liveness probe for application status

#### CLI Health Command
- `parity-client health` - Command line health check
- `parity-client health --detailed` - Detailed health information
- `parity-client health --endpoint <url>` - Custom endpoint support
- `parity-client health --timeout <duration>` - Configurable timeout

#### Real-Time Data Collection
- Uptime tracking since application start
- Version information from git tags and build metadata
- Live connectivity tests to blockchain, IPFS, and runner services
- Latency measurements for each service
- Real configuration values from environment

### Technical Implementation

#### Service Health Checks
- Blockchain: Uses ethclient.Dial() and BlockNumber() for connectivity
- IPFS: Uses shell.Version() for IPFS API connectivity
- Runner: HTTP health check to runner service endpoint
- Error handling with detailed error messages

#### Version Management
- Version package for centralized version management
- Build-time injection of git tags, commit SHA, and build timestamp
- Runtime platform and Go version information

#### Kubernetes Integration
- Readiness probe returns 503 if dependencies unavailable
- Liveness probe for application status check
- Proper HTTP status codes for monitoring systems

### Usage Examples

#### Command Line
```bash
# Basic health check
parity-client health

# Detailed health information
parity-client health --detailed

# Custom endpoint with timeout
parity-client health --endpoint http://localhost:8080 --timeout 30s
```

#### HTTP API
```bash
# Basic health check
curl http://localhost:3000/health

# Detailed health information
curl http://localhost:3000/health/detailed

# Kubernetes probes
curl http://localhost:3000/health/ready
curl http://localhost:3000/health/live
```

### Response Format

#### Basic Health Check
```json
{
  "status": "healthy",
  "timestamp": "2024-01-15T10:30:00Z",
  "version": "v1.0.0",
  "uptime": "2h30m15s",
  "services": {
    "blockchain": "configured",
    "ipfs": "configured",
    "runner": "configured"
  }
}
```

#### Detailed Health Check
```json
{
  "status": "healthy",
  "timestamp": "2024-01-15T10:30:00Z",
  "version": "v1.0.0",
  "uptime": "2h30m15s",
  "services": {
    "blockchain": {
      "status": "healthy",
      "last_check": "2024-01-15T10:29:55Z",
      "latency": "125ms"
    },
    "ipfs": {
      "status": "healthy",
      "last_check": "2024-01-15T10:29:58Z",
      "latency": "45ms"
    },
    "runner": {
      "status": "healthy",
      "last_check": "2024-01-15T10:30:00Z",
      "latency": "78ms"
    }
  },
  "config": {
    "server_host": "0.0.0.0",
    "server_port": 3000,
    "blockchain_rpc": "https://your-blockchain-node.com",
    "ipfs_endpoint": "http://localhost:5001",
    "runner_url": "http://localhost:8080"
  }
}
```